### PR TITLE
Correct permissions to /var/log/ocsinventory-server/ in startup script

### DIFF
--- a/2.3.1/scripts/run.sh
+++ b/2.3.1/scripts/run.sh
@@ -6,4 +6,5 @@ fi
 if [ -f "$APACHE_PID_FILE" ]; then
 	rm "$APACHE_PID_FILE"
 fi
+chown -R $APACHE_RUN_USER:$APACHE_RUN_GROUP /var/log/ocsinventory-server
 /usr/sbin/apache2ctl -D FOREGROUND


### PR DESCRIPTION
When running the container hosts can't send information to ocsinventory-server; in /var/log/apache2/error.log i found:
`````
[Tue Aug 01 16:12:06.363306 2017] [perl:error] [pid 25] [client 192.168.82.95:37667] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:12:20.256404 2017] [perl:error] [pid 10] [client 192.168.55.122:1167] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:12:46.624515 2017] [perl:error] [pid 16] [client 192.168.55.122:1168] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:13:34.178575 2017] [perl:error] [pid 27] [client 192.168.171.223:3084] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:13:46.241600 2017] [perl:error] [pid 22] [client 192.168.116.128:44482] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:13:48.286779 2017] [perl:error] [pid 25] [client 192.168.54.217:58346] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:13:52.842540 2017] [perl:error] [pid 22] [client 192.168.55.122:1172] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:14:04.640218 2017] [perl:error] [pid 18] [client 192.168.54.217:58347] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:14:32.842274 2017] [perl:error] [pid 22] [client 192.168.54.217:58348] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
[Tue Aug 01 16:14:43.665210 2017] [perl:error] [pid 25] [client 192.168.54.217:58349] Failed to open log file : Permission denied (/var/log/ocsinventory-server)\n
`````

This PR corrects the permissions on the /var/log/ocsinventory-server path at container startup setting them recursively to $APACHE_RUN_USER:$APACHE_RUN_GROUP